### PR TITLE
Fix return type; add additional check for Thursday

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -88,13 +88,13 @@ class ApiController extends Controller {
 	 * @return string
 	 */
 	private static function getRoom(Talk $talk) : string {
-		if(preg_match('/Thursday Room (\d+)/', $talk->day, $matches)) {
+		if(preg_match('/Thursday Room (\d+)/', $talk->day, $matches) || $talk->day == 'Thursday') {
 			return "Johnson Hall room {$matches[1]}";
 		}
 		if($talk->day == 'Friday' || $talk->day == 'Saturday') {
 			return 'Kane Hall room 220';
 		}
-		return null;
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
This is totally an error on my part (returning null in a function declared to return a string), but the data I have in my working copy doesn't ever hit that condition.

Also check for schedule days of "Thursday" in addition to "Thursday Room nnn" just in case.