### PR TITLE
Fix out-of-order event list on mobile (or narrow) screens

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Event;
+use App\Models\HasStartTime;
 use App\Models\Talk;
 
 class EventController extends Controller
@@ -36,7 +37,9 @@ class EventController extends Controller
             $events = $this->sortByStartTime($events, 'events');
 
             $today = array_merge($talks, $events);
-            asort($today);
+            uasort($today, function(HasStartTime $a, HasStartTime $b) {
+                return $a->getStartsAt() <=> $b->getStartsAt();
+            });
             $schedule[$name] = $today;
         }
         return view('event.schedule')->with([ 'schedule' => $schedule ]);

--- a/app/Models/Api/DateFixer.php
+++ b/app/Models/Api/DateFixer.php
@@ -31,4 +31,11 @@ trait DateFixer {
 		}
 		return '2000-01-01';
 	}
+
+    public function getStartsAt() : \DateTimeInterface
+    {
+        return \DateTimeImmutable::createFromFormat('Y-m-d H:i:s',
+            $this->getDate() . ' ' . $this->start_time . ':00',
+            new \DateTimeZone('America/Los_Angeles'));
+    }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -2,7 +2,7 @@
 
 use App\Models\Api\DateFixer;
 
-class Event extends BaseModel
+class Event extends BaseModel implements HasStartTime
 {
 	use DateFixer;
     protected $fillable = [ 'name', 'desc', 'start_time', 'end_time', 'day', 'location' ];

--- a/app/Models/HasStartTime.php
+++ b/app/Models/HasStartTime.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Models;
+
+interface HasStartTime
+{
+    public function getStartsAt() : \DateTimeInterface;
+}

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -2,7 +2,7 @@
 
 use App\Models\Api\DateFixer;
 
-class Talk extends BaseModel
+class Talk extends BaseModel implements HasStartTime
 {
 	use DateFixer;
     protected $fillable = [ 'name', 'desc', 'designation', 'category', 'level', 'start_time', 'end_time', 'day' ];

--- a/database/seeds/TalksTableSeeder.php
+++ b/database/seeds/TalksTableSeeder.php
@@ -14,27 +14,22 @@ class TalksTableSeeder extends Seeder
      */
     public function run()
     {
-        $days = [
-            0,1,2,3,4
-        ];
-        foreach ($days as $day) {
-            $start = rand(9,12);
-            for($i = $start; $i < 20; $i += rand(1,2)) {
-                if (rand(0,1)) {
-                    factory(App\Models\Talk::class)->create([
-                        'day' => $day,
-                        'start_time' => $i.':00',
-                        'end_time' => $i+1 . ':00'
-                    ]);
-                } else {
-                    factory(App\Models\Event::class)->create([
-                        'day' => $day,
-                        'start_time' => $i.':00',
-                        'end_time' => $i+1 . ':00'
-                    ]);
-                }
-            }
+        $eventsList = [];
+
+        for ($i = 0; $i < 30; $i++) {
+            do {
+                $day = rand(0, 4);
+                $startHour = rand(9, 20);
+            } while (isset($eventsList[$day . '-' . $startHour]));
+            $eventsList[$day . '-' . $startHour] = true;
+
+            factory(rand(0,1) ? App\Models\Talk::class : App\Models\Event::class)->create([
+                'day' => $day,
+                'start_time' => $startHour.':00',
+                'end_time' => $startHour + 1 . ':00'
+            ]);
         }
+
         $talks = Talk::all();
         $speakerCount = [1,1,1,1,1,2,3];
         foreach ($talks as $talk) {


### PR DESCRIPTION
On production, events are sorted by day, then by ID. This means that newly created events show up "later" than old ones, even if they're earlier, on narrow screens that trigger the mobile style media query, where dates are rows rather than columns.

This PR does a few things:
1. Revises the db seeder to insert events in non-chronological (well, random, so in theory it *could* be chronological) order. This allows the above bug to be reproduced locally; the old seeder added earlier events first, and thus wouldn't reproduce this issue.
2. Re-sorts schedule items by start date before passing to the view, so events show up in start time order within a day on the DOM, fixing the mobile view issue.